### PR TITLE
Enable owner pull request auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v3
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_NOTIFY_USER_LIST: ""
 
   rails:

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Owner Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  owner:
+    if: github.event.pull_request.user.login == 'Builder106' && github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: |
+          output=$(gh pr merge --auto --squash "$PR_URL" 2>&1) || {
+            case "$output" in
+              *"already in progress"*|*"already auto-merged"*|*"already merged"*|*"not open"*)
+                echo "Auto-merge already handled: $output"
+                exit 0
+                ;;
+              *)
+                echo "::error::$output"
+                exit 1
+                ;;
+            esac
+          }
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Owner Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  owner:
+    if: github.event.pull_request.user.login == 'Builder106' && github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds a trusted pull_request_target workflow that enables squash auto-merge only for Builder106-authored PRs targeting the default branch from an in-repository branch. The workflow does not check out or execute pull request code.