### PR TITLE
Enable owner pull request auto-merge

### DIFF
--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -15,7 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          output=$(gh pr merge --auto --squash "$PR_URL" 2>&1) || {
+            case "$output" in
+              *"already in progress"*|*"already auto-merged"*|*"already merged"*|*"not open"*)
+                echo "Auto-merge already handled: $output"
+                exit 0
+                ;;
+              *)
+                echo "::error::$output"
+                exit 1
+                ;;
+            esac
+          }
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Owner Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  owner:
+    if: github.event.pull_request.user.login == 'Builder106' && github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Add idempotent GitHub Actions workflow to enable auto-squash-merge for owner-authored pull requests.